### PR TITLE
A few suggestions

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -37,7 +37,7 @@
       where the Charter is being developed.
     </p>
     <ul>
-      <li>This Charter: <a href="https://github.com/openactive/openactive-w3c-cg/charter.html">https://github.com/openactive/openactive-w3c-cg/charter.html</a>
+      <li>This Charter: <a href="https://github.com/openactive/openactive-w3c-cg/blob/master/charter.html">https://github.com/openactive/openactive-w3c-cg/blob/master/charter.html</a>
       </li>
       <li>Start Date: 2016-11-22
       </li>
@@ -95,6 +95,12 @@
     already defines a standard for publishing scores, lineups, schedules, 
     standards and relevant statistics.
     </p>
+    <p>
+    The community group is focussed on specifications that enable the description, sharing
+    and manipulation of opportunity data (data that describes a physical activity including
+    what it is, where and when it's taking place). Participation data, such as an audit trail
+    of activities that have occurred, who has attended, etc. is out of scope.
+    </p>  
     <h2 id="deliverables">
       Deliverables
     </h2>


### PR DESCRIPTION
Perhaps also rename to "w3c-cg" as it's already in the namespace "openactive"?

"minutes will be posted to the group's public mailing list, or to a GitHub issue if the group uses GitHub." <- are we making a decision between these? Shall we pick one, or leave it to the community to decide? (I've seen schema.org make good use of GitHub Issues for purposes other than "Issues".